### PR TITLE
Timing fixes (v2)

### DIFF
--- a/include/serial_port.hpp
+++ b/include/serial_port.hpp
@@ -56,6 +56,7 @@ class serial_port
 
         std::size_t p_write( const uint8_t * data, std::size_t size );
         std::size_t p_read(  uint8_t * data, std::size_t size );
+	int delay(int);
 
     protected:
     #if( !__WIN32 )

--- a/lib/device_c.cpp
+++ b/lib/device_c.cpp
@@ -40,6 +40,7 @@ struct __attribute__(( packed )) lmc_command
 
 namespace Device
 {
+    static const int DELAY = 170000;
     static const float INCHES_TO_C_UNITS = 404.0f;
     static const float C_UNITS_TO_INCHES = ( 1 / (INCHES_TO_C_UNITS) );
 
@@ -99,11 +100,13 @@ namespace Device
 
     bool C::start()
     {
+        m_serial.delay(DELAY);
         return m_serial.p_write( cmd_start, sizeof( cmd_start ) );
     }
 
     bool C::stop()
     {
+        m_serial.delay(DELAY);
         return m_serial.p_write( cmd_stop, sizeof( cmd_stop ) );
     }
 
@@ -150,6 +153,7 @@ namespace Device
         return buf;
     }
 }
+
 
 /******************************************
 Host endianness TO device C endianness Long

--- a/lib/serial_port.cpp
+++ b/lib/serial_port.cpp
@@ -144,7 +144,7 @@ size_t serial_port::p_write( const uint8_t * data, size_t size )
     int      count = 0;
     for( i = 0; i < size; ++i )
     {
-        usleep(1000);
+	delay(1000);
 
         if( write( fd, data, 1 ) == 1 )
         {

--- a/lib/serial_port.cpp
+++ b/lib/serial_port.cpp
@@ -177,3 +177,8 @@ const uint64_t serial_port::getTime( void )
     gettimeofday( &tv, NULL );
     return (uint64_t)tv.tv_sec * 1000000 + (uint64_t)tv.tv_usec ;
 }
+
+int serial_port::delay( int usecs )
+{
+    return usleep(usecs);
+}

--- a/lib/serial_port_win32.cpp
+++ b/lib/serial_port_win32.cpp
@@ -161,3 +161,9 @@ const uint64_t serial_port::getTime( void )
     gettimeofday( &tv, NULL );
     return (uint64_t)tv.tv_sec * 1000000 + (uint64_t)tv.tv_usec ;
 }
+
+
+int serial_port::delay( int usecs )
+{
+    return usleep(usecs);
+}

--- a/lib/serial_port_win32.cpp
+++ b/lib/serial_port_win32.cpp
@@ -120,7 +120,7 @@ size_t serial_port::p_write( const uint8_t * data, size_t size )
 
     for( i = 0; i < size; ++i )
     {
-        usleep(1000);
+	delay(1000);
 
         if( WriteFile( fd, data, 1, &bytesWritten, NULL ) )
         {
@@ -165,5 +165,6 @@ const uint64_t serial_port::getTime( void )
 
 int serial_port::delay( int usecs )
 {
-    return usleep(usecs);
+    Sleep((usecs+999)/1000);
+    return 0;
 }


### PR DESCRIPTION
When the device is initialised for USB comms Device::C sends a stop() command followed by a start() command. When those messages are sent with no delay between them the device appears to become confused, and (presumably) resolves the confusion by returning to it's waiting state and ignoring subsequent USB commands. This patch introduces a delay before issuing those commands, so that it's impossible to issue a sequence of them any faster than the device can handle them.

The current delay is set to 170ms - this value was achieved via trial and error, and is the smallest value that worked in my testing with a Cricut Expressions running v2.35 firmware driven by a modern laptop. Other combinations of device/firmware/host may require different delays.

In addition there are some minor changes to the win32 serial port code to properly(?) support these delays.