### PR TITLE
Allow users to provide keys at runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/
+.DS_Store

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,21 @@
+{
+    "configurations": [
+        {
+            "name": "Mac, working",
+            "includePath": [
+                "${workspaceFolder}/**"
+            ],
+            "defines": [],
+            "macFrameworkPath": [],
+            "compilerPath": "/opt/homebrew/bin/gcc-10",
+            "cStandard": "gnu17",
+            "cppStandard": "gnu++17",
+            "intelliSenseMode": "macos-gcc-arm64"
+        },
+        {
+            "name": "Mac CMAKE",
+            "configurationProvider": "ms-vscode.cmake-tools"
+        }
+    ],
+    "version": 4
+}

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -3,7 +3,9 @@
         {
             "name": "Mac, working",
             "includePath": [
-                "${workspaceFolder}/**"
+                "${workspaceFolder}/**",
+                "/usr/local/include",
+                "/opt/homebrew/include"
             ],
             "defines": [],
             "macFrameworkPath": [],

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 project (libcutter)
-cmake_minimum_required(VERSION 2.6.0)
+cmake_minimum_required(VERSION 2.6.0...3.19.1)
     if(COMMAND cmake_policy)
       cmake_policy(SET CMP0003 NEW)
     endif(COMMAND cmake_policy)
@@ -7,6 +7,10 @@ include_directories(${PROJECT_SOURCE_DIR}/include/ ${PROJECT_SOURCE_DIR}/include
 option(SERIAL_PORT_DEBUG_MODE "Serial debugging" ON)
 set(CMAKE_CXX_FLAGS "-g -Wall")
 set(CMAKE_C_FLAGS "-g -Wall")
+
+# Use C++11 at least
+set(CMAKE_CXX_STANDARD 11)
+
 add_subdirectory(lib)
 add_subdirectory(util)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,8 @@ option(SERIAL_PORT_DEBUG_MODE "Serial debugging" ON)
 set(CMAKE_CXX_FLAGS "-g -Wall")
 set(CMAKE_C_FLAGS "-g -Wall")
 
-# Use C++11 at least
-set(CMAKE_CXX_STANDARD 11)
+# Use C++17 at least
+set(CMAKE_CXX_STANDARD 17)
 
 add_subdirectory(lib)
 add_subdirectory(util)

--- a/README.md
+++ b/README.md
@@ -22,12 +22,25 @@ libcutter itself does not have many dependencies outside of OS-level serial port
 - libpng - needed by libsvg
 - SDL1.2 & SDL1.2GFX - needed by some of the simulator tools
 
-## Building for Linux/UNIX
-- mkdir build
-- cd build
-- cmake ..
-- make
-- ./util/some-program
+### Installing libsvg
+
+If you're on a Mac (though you may need to wait for [the formula to be fixed](https://github.com/Homebrew/homebrew-core/pull/68760)):
+
+```bash
+brew install libsvg # or `brew install --build-from-source libsvg`
+```
+
+Otherwise, extract the file in the `deps/` directory and follow the instructions in `INSTALL`. You may need to apply the patch mentioned above: patch `png_set_gray_1_2_4_to_8` to `png_set_expand_gray_1_2_4_to_8` in `src/svg_image.c`.
+
+## Building for Linux/UNIX/Mac
+
+From this directory:
+
+- `mkdir build`
+- `cd build`
+- `cmake ..`
+- `make`
+- Yay! Now you can run the code: `./util/some-program`
 
 ## Building for Windows 
 To build for win32, you first need MinGW (look at the mingw32 packages on Debian).

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ By default, this project compiles for runtime keys. If you would like to specify
 1. Remove the `#define NO_COMPILE_TIME_KEYS` block.
 2. Replace all the dummy keys with your keys.
 
-If you do not specify compile-time keys, your must provide a configuration file at runtime. This looks very similar to `keys.h`---it is a simple text file with a key's name and a key on each line, separated by whitespace. Like this (using fake keys):
+If you do not specify compile-time keys, you must provide a configuration file at runtime. This looks very similar to `keys.h`---it is a simple text file with a key's name and a key on each line, separated by whitespace. Like this (using fake keys):
 
 ```
 MOVE_KEY_0  0x0123abcd

--- a/README.md
+++ b/README.md
@@ -7,8 +7,39 @@ Film at 11.
 - Cricut Expression - v2.31
 
 # Encryption / communication keys
-These are not provided with the library for various reasons. See include/pub/keys.h.
-Please do not ask for them here or elsewhere.
+These are not provided with the library for various reasons. Please do not ask
+for them here or elsewhere.
+
+## Providing keys
+
+You have two options for providing these keys:
+
+* Provide them at runtime, using a config file, for maximum flexibility.
+* Provide them at compile-time, so you don't have to use a config file each time.
+
+By default, this project compiles for runtime keys. If you would like to specify compile-time keys, see `include/pub/keys.h`. Simply:
+
+1. Remove the `#define NO_COMPILE_TIME_KEYS` block.
+2. Replace all the dummy keys with your keys.
+
+If you do not specify compile-time keys, your must provide a configuration file at runtime. This looks very similar to `keys.h`---it is a simple text file with a key's name and a key on each line, separated by whitespace. Like this (using fake keys):
+
+```
+MOVE_KEY_0  0x0123abcd
+MOVE_KEY_1  0x0123abcd
+MOVE_KEY_2  0x0123abcd
+MOVE_KEY_3  0x0123abcd
+LINE_KEY_0  0x0123abcd
+LINE_KEY_1  0x0123abcd
+LINE_KEY_2  0x0123abcd
+LINE_KEY_3  0x0123abcd
+CURVE_KEY_0  0x0123abcd
+CURVE_KEY_1  0x0123abcd
+CURVE_KEY_2  0x0123abcd
+CURVE_KEY_3  0x0123abcd
+```
+
+Running any command that requires keys will also explain this format :).
 
 # Developer Notes
 ## Code formatting

--- a/include/pub/keys.h
+++ b/include/pub/keys.h
@@ -1,5 +1,9 @@
 #ifndef KEYS_H
-#warning Keys must be defined!
+
+// Remove this block when adding keys
+#define NO_COMPILE_TIME_KEYS
+// End block
+
 #define MOVE_KEY_0   0ul
 #define MOVE_KEY_1   1ul
 #define MOVE_KEY_2   2ul

--- a/include/types.h
+++ b/include/types.h
@@ -36,5 +36,6 @@ struct xy
 	~xy(){};
 };
 
-typedef uint32_t ckey_type[4];
+typedef uint32_t individual_key_t;
+typedef individual_key_t ckey_type[4];
 #endif

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,5 +1,5 @@
 project (libcutter)
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 2.6.4...3.19)
     if(COMMAND cmake_policy)
       cmake_policy(SET CMP0003 NEW)
     endif(COMMAND cmake_policy)

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -37,7 +37,7 @@ target_link_libraries (test_serial cutter)
 add_executable (draw_gcode draw_gcode.cpp gcode.cpp KeyConfigParser.hpp KeyConfigParser.cpp)
 target_link_libraries (draw_gcode cutter)
 
-add_executable (draw_svg draw_svg.cpp)
+add_executable (draw_svg draw_svg.cpp KeyConfigParser.hpp KeyConfigParser.cpp)
 target_link_libraries (draw_svg cutter svg jpeg png)
 
 add_executable (test_btea test_btea.cpp)

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -23,7 +23,7 @@ add_executable (test_endian test_endian.cpp)
 add_executable (test_serial test_serial.cpp)
 target_link_libraries (test_serial cutter)
 
-add_executable (draw_gcode draw_gcode.cpp gcode.cpp)
+add_executable (draw_gcode draw_gcode.cpp gcode.cpp KeyConfigParser.hpp KeyConfigParser.cpp)
 target_link_libraries (draw_gcode cutter)
 
 add_executable (draw_svg draw_svg.cpp)

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -15,6 +15,17 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     target_link_libraries (jsdrive_relative cutter pthread )
 endif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
 
+IF(APPLE)
+    # Fix linking on 10.14+. See https://stackoverflow.com/questions/54068035
+    link_directories("/opt/local/lib")
+    include_directories("/opt/local/include")
+
+    # Fix for M1 Macs, where Homebrew uses a different location. See
+    # https://apple.stackexchange.com/questions/410825/apple-silicon-port-all-homebrew-packages-under-usr-local-opt-to-opt-homebrew
+    link_directories("/opt/homebrew/lib")
+    include_directories("/opt/homebrew/include")
+ENDIF()
+
 add_executable (test_speed test_speed.cpp)
 target_link_libraries (test_speed cutter)
 

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -26,7 +26,7 @@ IF(APPLE)
     include_directories("/opt/homebrew/include")
 ENDIF()
 
-add_executable (test_speed test_speed.cpp)
+add_executable (test_speed test_speed.cpp KeyConfigParser.hpp KeyConfigParser.cpp)
 target_link_libraries (test_speed cutter)
 
 add_executable (test_endian test_endian.cpp)

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -1,5 +1,5 @@
 project (libcutter)
-cmake_minimum_required(VERSION 2.6.0)
+cmake_minimum_required(VERSION 2.6.0...3.19)
     if(COMMAND cmake_policy)
         cmake_policy(SET CMP0003 NEW)
     endif(COMMAND cmake_policy)

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -32,7 +32,7 @@ target_link_libraries (draw_svg cutter svg jpeg png)
 add_executable (test_btea test_btea.cpp)
 target_link_libraries (test_btea cutter)
 
-add_executable (interpreter interpreter.cpp)
+add_executable (interpreter interpreter.cpp KeyConfigParser.hpp KeyConfigParser.cpp)
 target_link_libraries (interpreter cutter)
 
 if(HAS_SDL)

--- a/util/KeyConfigParser.cpp
+++ b/util/KeyConfigParser.cpp
@@ -1,6 +1,8 @@
 #include "KeyConfigParser.hpp"
 
 #include <fstream>
+#include <sstream>
+#include <iostream>
 
 namespace
 {
@@ -35,14 +37,25 @@ KeyConfigParser::KeyConfigParser(const std::string& configFilePath)
         std::string keyValue;
         fileStream >> keyName >> keyValue;
 
-        auto keySet = getKeySetForKeyName(keyName);
-        auto specificKey = getKeyForKeyName(keySet, keyName);
-        specificKey = std::stoul(keyValue, nullptr /* idx */, 16 /* base */);
+        auto& keySet = getKeySetForKeyName(keyName);
+        auto& specificKey = getKeyForKeyName(keySet, keyName);
+        const auto value = std::stoul(keyValue, nullptr /* idx */, 16 /* base */);
+        specificKey = value;
+
+        // Debug
+        // std::cout << keyName << ": " << value << " (" << keyValue << ")" << std::endl;
     }
 
     if (!isComplete())
     {
-        throw std::invalid_argument("Incomplete configuration file. You need keys 0-3 for MOVE, LINE, and CURVE.");
+        std::stringstream errorMessage;
+        errorMessage << "Incomplete configuration file. You need keys 0-3 for MOVE, LINE, and CURVE." << std::endl;
+        errorMessage << std::endl;
+        errorMessage << "Move keys: " << m_moveKeys.key0.value_or(0ul) << std::endl;
+        errorMessage << "Line keys: " << m_lineKeys.key0.value_or(0ul) << std::endl;
+        errorMessage << "Curve keys: " << m_curveKeys.key0.value_or(0ul) << std::endl;
+        errorMessage << std::endl;
+        throw std::invalid_argument(errorMessage.str());
     }
 }
 

--- a/util/KeyConfigParser.cpp
+++ b/util/KeyConfigParser.cpp
@@ -46,8 +46,10 @@ KeyConfigParser::KeyConfigParser(const std::string& configFilePath)
 
     while (fileStream.good())
     {
-        // Formatted extraction pulls a string and a ulong from a string,
-        // separated by whitespace.
+        // Formatted extraction pulls two strings from a string, separated by
+        // whitespace. The first should be the "name" of the key, followed by
+        // the value it should have. We use `stoul` so that users can provide
+        // the number in formats like `0x00ul`, `0ul`, and `0`.
         std::string keyName;
         std::string keyValue;
         fileStream >> keyName >> keyValue;

--- a/util/KeyConfigParser.cpp
+++ b/util/KeyConfigParser.cpp
@@ -4,10 +4,16 @@
 
 namespace
 {
+    // https://stackoverflow.com/questions/1878001/how-do-i-check-if-a-c-stdstring-starts-with-a-certain-string-and-convert-a
     bool startsWith(const std::string& str, const std::string& needle)
     {
-        // https://stackoverflow.com/questions/1878001/how-do-i-check-if-a-c-stdstring-starts-with-a-certain-string-and-convert-a
         return (str.rfind(needle, 0) == 0);
+    }
+
+    // https://stackoverflow.com/questions/874134/find-out-if-string-ends-with-another-string-in-c
+    bool endsWith(const std::string& str, const std::string& suffix)
+    {
+        return str.size() >= suffix.size() && 0 == str.compare(str.size()-suffix.size(), suffix.size(), suffix);
     }
 } // namespace anonymous
 
@@ -30,7 +36,13 @@ KeyConfigParser::KeyConfigParser(const std::string& configFilePath)
         fileStream >> keyName >> keyValue;
 
         auto keySet = getKeySetForKeyName(keyName);
-        
+        auto specificKey = getKeyForKeyName(keySet, keyName);
+        specificKey = keyValue;
+    }
+
+    if (!isComplete())
+    {
+        throw std::invalid_argument("Incomplete configuration file. You need keys 0-3 for MOVE, LINE, and CURVE.");
     }
 }
 
@@ -62,6 +74,30 @@ KeyConfigParser::KeySet& KeyConfigParser::getKeySetForKeyName(std::string keyNam
     else if (startsWith(keyName, "CURVE_KEY"))
     {
         return m_curveKeys;
+    }
+    else
+    {
+        throw std::invalid_argument(std::string("Unknown key: ").append(keyName));
+    }
+}
+
+std::optional<unsigned long>& KeyConfigParser::getKeyForKeyName(KeyConfigParser::KeySet& keySet, std::string keyName) const
+{
+    if (endsWith(keyName, "0"))
+    {
+        return keySet.key0;
+    }
+    else if (endsWith(keyName, "1"))
+    {
+        return keySet.key1;
+    }
+    else if (endsWith(keyName, "2"))
+    {
+        return keySet.key2;
+    }
+    else if (endsWith(keyName, "3"))
+    {
+        return keySet.key3;
     }
     else
     {

--- a/util/KeyConfigParser.cpp
+++ b/util/KeyConfigParser.cpp
@@ -30,7 +30,23 @@ KeyConfigParser::KeyConfigParser(const std::string& configFilePath)
         fileStream >> keyName >> keyValue;
 
         auto keySet = getKeySetForKeyName(keyName);
+        
     }
+}
+
+bool KeyConfigParser::isKeySetComplete(const KeyConfigParser::KeySet& keySet) const
+{
+    return keySet.key0.has_value() &&
+        keySet.key1.has_value() &&
+        keySet.key2.has_value() &&
+        keySet.key3.has_value();
+}
+
+bool KeyConfigParser::isComplete() const
+{
+    return isKeySetComplete(m_moveKeys) &&
+        isKeySetComplete(m_lineKeys) &&
+        isKeySetComplete(m_curveKeys);
 }
 
 KeyConfigParser::KeySet& KeyConfigParser::getKeySetForKeyName(std::string keyName)

--- a/util/KeyConfigParser.cpp
+++ b/util/KeyConfigParser.cpp
@@ -17,6 +17,21 @@ namespace
     {
         return str.size() >= suffix.size() && 0 == str.compare(str.size()-suffix.size(), suffix.size(), suffix);
     }
+
+    template<typename T>
+    std::string toString(std::optional<T> opt)
+    {
+        if (opt.has_value())
+        {
+            std::stringstream ss;
+            ss << *opt;
+            return ss.str();
+        }
+        else
+        {
+            return "(missing)";
+        }
+    }
 } // namespace anonymous
 
 KeyConfigParser::KeyConfigParser(const std::string& configFilePath)
@@ -51,9 +66,9 @@ KeyConfigParser::KeyConfigParser(const std::string& configFilePath)
         std::stringstream errorMessage;
         errorMessage << "Incomplete configuration file. You need keys 0-3 for MOVE, LINE, and CURVE." << std::endl;
         errorMessage << std::endl;
-        errorMessage << "Move keys: " << m_moveKeys.key0.value_or(0ul) << std::endl;
-        errorMessage << "Line keys: " << m_lineKeys.key0.value_or(0ul) << std::endl;
-        errorMessage << "Curve keys: " << m_curveKeys.key0.value_or(0ul) << std::endl;
+        errorMessage << "Move keys: " << m_moveKeys.str() << std::endl;
+        errorMessage << "Line keys: " << m_lineKeys.str() << std::endl;
+        errorMessage << "Curve keys: " << m_curveKeys.str() << std::endl;
         errorMessage << std::endl;
         throw std::invalid_argument(errorMessage.str());
     }
@@ -72,6 +87,21 @@ KeySet KeyConfigParser::lineKeys() const
 KeySet KeyConfigParser::curveKeys() const
 {
     return toKeySet(m_curveKeys);
+}
+
+std::string KeyConfigParser::OptionalKeySet::str() const
+{
+    std::stringstream str;
+    str << "[";
+    str << toString(key0);
+    str << ", ";
+    str << toString(key1);
+    str << ", ";
+    str << toString(key2);
+    str << ", ";
+    str << toString(key3);
+    str << "]";
+    return str.str();
 }
 
 bool KeyConfigParser::isKeySetComplete(const KeyConfigParser::OptionalKeySet& keySet) const

--- a/util/KeyConfigParser.cpp
+++ b/util/KeyConfigParser.cpp
@@ -1,0 +1,54 @@
+#include "KeyConfigParser.hpp"
+
+#include <fstream>
+
+namespace
+{
+    bool startsWith(const std::string& str, const std::string& needle)
+    {
+        // https://stackoverflow.com/questions/1878001/how-do-i-check-if-a-c-stdstring-starts-with-a-certain-string-and-convert-a
+        return (str.rfind(needle, 0) == 0);
+    }
+} // namespace anonymous
+
+KeyConfigParser::KeyConfigParser(const std::string& configFilePath)
+{
+    // Open the file!
+    std::ifstream fileStream(configFilePath);
+
+    if (!fileStream.is_open())
+    {
+        throw std::invalid_argument("Could not open config file");
+    }
+
+    while (fileStream.good())
+    {
+        // Formatted extraction pulls a string and a ulong from a string,
+        // separated by whitespace.
+        std::string keyName;
+        unsigned long keyValue;
+        fileStream >> keyName >> keyValue;
+
+        auto keySet = getKeySetForKeyName(keyName);
+    }
+}
+
+KeyConfigParser::KeySet& KeyConfigParser::getKeySetForKeyName(std::string keyName)
+{
+    if (startsWith(keyName, "MOVE_KEY"))
+    {
+        return m_moveKeys;
+    }
+    else if (startsWith(keyName, "LINE_KEY"))
+    {
+        return m_lineKeys;
+    }
+    else if (startsWith(keyName, "CURVE_KEY"))
+    {
+        return m_curveKeys;
+    }
+    else
+    {
+        throw std::invalid_argument(std::string("Unknown key: ").append(keyName));
+    }
+}

--- a/util/KeyConfigParser.cpp
+++ b/util/KeyConfigParser.cpp
@@ -32,7 +32,7 @@ KeyConfigParser::KeyConfigParser(const std::string& configFilePath)
         // Formatted extraction pulls a string and a ulong from a string,
         // separated by whitespace.
         std::string keyName;
-        unsigned long keyValue;
+        individual_key_t keyValue;
         fileStream >> keyName >> keyValue;
 
         auto keySet = getKeySetForKeyName(keyName);
@@ -104,7 +104,7 @@ KeyConfigParser::OptionalKeySet& KeyConfigParser::getKeySetForKeyName(std::strin
     }
 }
 
-std::optional<unsigned long>& KeyConfigParser::getKeyForKeyName(KeyConfigParser::OptionalKeySet& keySet, std::string keyName) const
+std::optional<individual_key_t>& KeyConfigParser::getKeyForKeyName(KeyConfigParser::OptionalKeySet& keySet, std::string keyName) const
 {
     if (endsWith(keyName, "0"))
     {

--- a/util/KeyConfigParser.cpp
+++ b/util/KeyConfigParser.cpp
@@ -46,7 +46,22 @@ KeyConfigParser::KeyConfigParser(const std::string& configFilePath)
     }
 }
 
-bool KeyConfigParser::isKeySetComplete(const KeyConfigParser::KeySet& keySet) const
+KeySet KeyConfigParser::moveKeys() const
+{
+    return toKeySet(m_moveKeys);
+}
+
+KeySet KeyConfigParser::lineKeys() const
+{
+    return toKeySet(m_lineKeys);
+}
+
+KeySet KeyConfigParser::curveKeys() const
+{
+    return toKeySet(m_curveKeys);
+}
+
+bool KeyConfigParser::isKeySetComplete(const KeyConfigParser::OptionalKeySet& keySet) const
 {
     return keySet.key0.has_value() &&
         keySet.key1.has_value() &&
@@ -61,7 +76,15 @@ bool KeyConfigParser::isComplete() const
         isKeySetComplete(m_curveKeys);
 }
 
-KeyConfigParser::KeySet& KeyConfigParser::getKeySetForKeyName(std::string keyName)
+KeySet KeyConfigParser::toKeySet(const KeyConfigParser::OptionalKeySet& keySet) const
+{
+    return KeySet(keySet.key0.value(),
+        keySet.key1.value(),
+        keySet.key2.value(),
+        keySet.key3.value());
+}
+
+KeyConfigParser::OptionalKeySet& KeyConfigParser::getKeySetForKeyName(std::string keyName)
 {
     if (startsWith(keyName, "MOVE_KEY"))
     {
@@ -81,7 +104,7 @@ KeyConfigParser::KeySet& KeyConfigParser::getKeySetForKeyName(std::string keyNam
     }
 }
 
-std::optional<unsigned long>& KeyConfigParser::getKeyForKeyName(KeyConfigParser::KeySet& keySet, std::string keyName) const
+std::optional<unsigned long>& KeyConfigParser::getKeyForKeyName(KeyConfigParser::OptionalKeySet& keySet, std::string keyName) const
 {
     if (endsWith(keyName, "0"))
     {

--- a/util/KeyConfigParser.cpp
+++ b/util/KeyConfigParser.cpp
@@ -32,12 +32,12 @@ KeyConfigParser::KeyConfigParser(const std::string& configFilePath)
         // Formatted extraction pulls a string and a ulong from a string,
         // separated by whitespace.
         std::string keyName;
-        individual_key_t keyValue;
+        std::string keyValue;
         fileStream >> keyName >> keyValue;
 
         auto keySet = getKeySetForKeyName(keyName);
         auto specificKey = getKeyForKeyName(keySet, keyName);
-        specificKey = keyValue;
+        specificKey = std::stoul(keyValue, nullptr /* idx */, 16 /* base */);
     }
 
     if (!isComplete())

--- a/util/KeyConfigParser.hpp
+++ b/util/KeyConfigParser.hpp
@@ -4,19 +4,21 @@
 #include <optional>
 #include <string>
 
+#include "types.h"
+
 class KeySet
 {
 public:
-    KeySet(unsigned long key0, unsigned long key1, unsigned long key2, unsigned long key3)
+    KeySet(individual_key_t key0, individual_key_t key1, individual_key_t key2, individual_key_t key3)
         : key0(key0), key1(key1), key2(key2), key3(key3)
     {
         // no-op
     }
 
-    unsigned long key0 = 0ul;
-    unsigned long key1 = 0ul;
-    unsigned long key2 = 0ul;
-    unsigned long key3 = 0ul;
+    individual_key_t key0 = 0ul;
+    individual_key_t key1 = 0ul;
+    individual_key_t key2 = 0ul;
+    individual_key_t key3 = 0ul;
 };
 
 /**
@@ -51,10 +53,10 @@ public:
 
 private:
     struct OptionalKeySet {
-        std::optional<unsigned long> key0;
-        std::optional<unsigned long> key1;
-        std::optional<unsigned long> key2;
-        std::optional<unsigned long> key3;
+        std::optional<individual_key_t> key0;
+        std::optional<individual_key_t> key1;
+        std::optional<individual_key_t> key2;
+        std::optional<individual_key_t> key3;
     };
 
     bool isKeySetComplete(const OptionalKeySet& keySet) const;
@@ -63,7 +65,7 @@ private:
     KeySet toKeySet(const OptionalKeySet& keySet) const;
 
     OptionalKeySet& getKeySetForKeyName(std::string keyName);
-    std::optional<unsigned long>& getKeyForKeyName(OptionalKeySet& keySet, std::string keyName) const;
+    std::optional<individual_key_t>& getKeyForKeyName(OptionalKeySet& keySet, std::string keyName) const;
 
     OptionalKeySet m_moveKeys{};
     OptionalKeySet m_lineKeys{};

--- a/util/KeyConfigParser.hpp
+++ b/util/KeyConfigParser.hpp
@@ -57,6 +57,8 @@ private:
         std::optional<individual_key_t> key1;
         std::optional<individual_key_t> key2;
         std::optional<individual_key_t> key3;
+
+        std::string str() const;
     };
 
     bool isKeySetComplete(const OptionalKeySet& keySet) const;

--- a/util/KeyConfigParser.hpp
+++ b/util/KeyConfigParser.hpp
@@ -42,6 +42,7 @@ private:
     bool isComplete() const;
 
     KeySet& getKeySetForKeyName(std::string keyName);
+    std::optional<unsigned long>& getKeyForKeyName(KeySet& keySet, std::string keyName) const;
 
     KeySet m_moveKeys{};
     KeySet m_lineKeys{};

--- a/util/KeyConfigParser.hpp
+++ b/util/KeyConfigParser.hpp
@@ -4,6 +4,21 @@
 #include <optional>
 #include <string>
 
+class KeySet
+{
+public:
+    KeySet(unsigned long key0, unsigned long key1, unsigned long key2, unsigned long key3)
+        : key0(key0), key1(key1), key2(key2), key3(key3)
+    {
+        // no-op
+    }
+
+    unsigned long key0 = 0ul;
+    unsigned long key1 = 0ul;
+    unsigned long key2 = 0ul;
+    unsigned long key3 = 0ul;
+};
+
 /**
  * Parse a "key config file"---a file containing the keys necessary to use the
  * cutter.
@@ -30,23 +45,29 @@ class KeyConfigParser
 public:
     KeyConfigParser(const std::string& configFilePath);
 
+    KeySet moveKeys() const;
+    KeySet lineKeys() const;
+    KeySet curveKeys() const;
+
 private:
-    struct KeySet {
+    struct OptionalKeySet {
         std::optional<unsigned long> key0;
         std::optional<unsigned long> key1;
         std::optional<unsigned long> key2;
         std::optional<unsigned long> key3;
     };
 
-    bool isKeySetComplete(const KeySet& keySet) const;
+    bool isKeySetComplete(const OptionalKeySet& keySet) const;
     bool isComplete() const;
 
-    KeySet& getKeySetForKeyName(std::string keyName);
-    std::optional<unsigned long>& getKeyForKeyName(KeySet& keySet, std::string keyName) const;
+    KeySet toKeySet(const OptionalKeySet& keySet) const;
 
-    KeySet m_moveKeys{};
-    KeySet m_lineKeys{};
-    KeySet m_curveKeys{};
+    OptionalKeySet& getKeySetForKeyName(std::string keyName);
+    std::optional<unsigned long>& getKeyForKeyName(OptionalKeySet& keySet, std::string keyName) const;
+
+    OptionalKeySet m_moveKeys{};
+    OptionalKeySet m_lineKeys{};
+    OptionalKeySet m_curveKeys{};
 };
 
 #endif

--- a/util/KeyConfigParser.hpp
+++ b/util/KeyConfigParser.hpp
@@ -1,0 +1,48 @@
+#ifndef CONFIGPARSER_HPP
+#define CONFIGPARSER_HPP
+
+#include <optional>
+#include <string>
+
+/**
+ * Parse a "key config file"---a file containing the keys necessary to use the
+ * cutter.
+ *
+ * This file is basically an INI file, but it's very simple:
+ *
+ * ```
+ * MOVE_KEY_0 0123abcd
+ * MOVE_KEY_1 0123abcd
+ * MOVE_KEY_2 0123abcd
+ * MOVE_KEY_3 0123abcd
+ * LINE_KEY_0 0123abcd
+ * LINE_KEY_1 0123abcd
+ * LINE_KEY_2 0123abcd
+ * LINE_KEY_3 0123abcd
+ * CURVE_KEY_0 0123abcd
+ * CURVE_KEY_1 0123abcd
+ * CURVE_KEY_2 0123abcd
+ * CURVE_KEY_3 0123abcd
+ * ```
+ */
+class KeyConfigParser
+{
+public:
+    KeyConfigParser(const std::string& configFilePath);
+
+private:
+    struct KeySet {
+        std::optional<unsigned long> key0;
+        std::optional<unsigned long> key1;
+        std::optional<unsigned long> key2;
+        std::optional<unsigned long> key3;
+    };
+
+    KeySet& getKeySetForKeyName(std::string keyName);
+
+    KeySet m_moveKeys{};
+    KeySet m_lineKeys{};
+    KeySet m_curveKeys{};
+};
+
+#endif

--- a/util/KeyConfigParser.hpp
+++ b/util/KeyConfigParser.hpp
@@ -38,6 +38,9 @@ private:
         std::optional<unsigned long> key3;
     };
 
+    bool isKeySetComplete(const KeySet& keySet) const;
+    bool isComplete() const;
+
     KeySet& getKeySetForKeyName(std::string keyName);
 
     KeySet m_moveKeys{};

--- a/util/draw_gcode.cpp
+++ b/util/draw_gcode.cpp
@@ -44,7 +44,7 @@ LaunchOptions parseArgs(int num_args, char * args[])
      while (i < num_args) 
      {
           auto currentArg = string(args[i]);
-          bool hasParsedDeviceFile = options.device_file.has_value();
+          const bool hasParsedDeviceFile = options.device_file.has_value();
 
           if (currentArg == "-d")
           {

--- a/util/draw_gcode.cpp
+++ b/util/draw_gcode.cpp
@@ -43,7 +43,7 @@ LaunchOptions parseArgs(int num_args, char * args[])
      int i = 1;
      while (i < num_args) 
      {
-          auto currentArg = string(args[i]);
+          const auto currentArg = string(args[i]);
           const bool hasParsedDeviceFile = options.device_file.has_value();
 
           if (currentArg == "-d")
@@ -51,7 +51,7 @@ LaunchOptions parseArgs(int num_args, char * args[])
                // The next argument is the debug level.
                options.debug_priority = (enum debug_prio)strtol(args[i + 1], NULL, 10);
                i += 2;
-               break;
+               continue;
           }
           else if (currentArg == "--mk")
           {
@@ -59,12 +59,12 @@ LaunchOptions parseArgs(int num_args, char * args[])
                     throw runtime_error("Not enough arguments; expected 4 keys.");
                }
                // The next 4 argument are the move keys
-               options.moveKey0 = stoi(args[i + 1], nullptr /* idx */, 16 /* base */);
-               options.moveKey1 = stoi(args[i + 2], nullptr /* idx */, 16 /* base */);
-               options.moveKey2 = stoi(args[i + 3], nullptr /* idx */, 16 /* base */);
-               options.moveKey3 = stoi(args[i + 4], nullptr /* idx */, 16 /* base */);
+               options.moveKey0 = stoul(args[i + 1], nullptr /* idx */, 16 /* base */);
+               options.moveKey1 = stoul(args[i + 2], nullptr /* idx */, 16 /* base */);
+               options.moveKey2 = stoul(args[i + 3], nullptr /* idx */, 16 /* base */);
+               options.moveKey3 = stoul(args[i + 4], nullptr /* idx */, 16 /* base */);
                i += 5;
-               break;
+               continue;
           }
           else if (!hasParsedDeviceFile)
           {
@@ -89,6 +89,11 @@ int main( int num_args, char * args[] )
      const auto launchOptions = parseArgs(num_args, args);
      if (!launchOptions.device_file || !launchOptions.gcode_file)
      {
+          cerr << "Please provide a device file and GCode file" << endl;
+          cerr << endl;
+          cerr << "Provided device: " << launchOptions.device_file.value_or("(missing)") << endl;
+          cerr << "Provided GCode: " << launchOptions.gcode_file.value_or("(missing)") << endl;
+          cerr << endl;
           usage(args[0]);
      }
 

--- a/util/draw_gcode.cpp
+++ b/util/draw_gcode.cpp
@@ -44,27 +44,30 @@ LaunchOptions parseArgs(int num_args, char * args[])
      while (i < num_args) 
      {
           auto currentArg = string(args[i]);
+          bool hasParsedDeviceFile = options.device_file.has_value();
 
-          if (currentArg == "-d") {
+          if (currentArg == "-d")
+          {
                // The next argument is the debug level.
                options.debug_priority = (enum debug_prio)strtol(args[i + 1], NULL, 10);
                i += 2;
                break;
           }
-          if (currentArg == "--mk0") {
+          else if (currentArg == "--mk0")
+          {
                // The next argument is the move key
                options.moveKey0 = stoi(args[i + 1], nullptr /* idx */, 16 /* base */);
                i += 2;
                break;
           }
-          else if (i == num_args - 2)
+          else if (!hasParsedDeviceFile)
           {
-               // Second-to-last argument is always device file
+               // First bare argument should be device file.
                options.device_file = currentArg;
           }
-          else if (i == num_args - 1)
+          else if (hasParsedDeviceFile)
           {
-               // Last argument is always device file
+               // Second bare argument should be gcode file.
                options.gcode_file = currentArg;
           }
 

--- a/util/draw_gcode.cpp
+++ b/util/draw_gcode.cpp
@@ -80,7 +80,22 @@ LaunchOptions parseArgs(int num_args, char * args[])
 
 int main( int num_args, char * args[] )
 {
-     const auto launchOptions = parseArgs(num_args, args);
+     const auto launchOptions = ([&]() -> LaunchOptions
+     {
+          try
+          {
+               return parseArgs(num_args, args);
+          }
+          catch(const std::exception& e)
+          {
+               std::cerr << "Failed to parse args:" << std::endl;
+               std::cerr << e.what() << std::endl;
+               std::cerr << std::endl;
+               usage(args[0]);
+               exit(1);
+          }
+     }());
+
      if (!launchOptions.device_file || !launchOptions.gcode_file)
      {
           #ifdef NO_COMPILE_TIME_KEYS
@@ -93,7 +108,7 @@ int main( int num_args, char * args[] )
           cerr << "Provided GCode: " << launchOptions.gcode_file.value_or("(missing)") << endl;
           #ifdef NO_COMPILE_TIME_KEYS
                cerr << "Provided key config: " << (launchOptions.key_config ? "Provided" : "(missing)") << endl;
-          #endif;
+          #endif
           cerr << endl;
           usage(args[0]);
      }

--- a/util/draw_gcode.cpp
+++ b/util/draw_gcode.cpp
@@ -17,7 +17,7 @@ using namespace std;
 
 void usage(char *progname)
 {
-     printf("Usage: %s -mk0 <move key 0> [-d debug_level] <device file> <gcode file>\n",
+     printf("Usage: %s --mk0 <move key 0> [-d debug_level] <device file> <gcode file>\n",
 	    progname);
      cout << "\tkeys - should point to a JSON file containing the movement keys for the machine" << endl;
      printf("%s\n", debug_msg.c_str());
@@ -26,8 +26,13 @@ void usage(char *progname)
 
 struct LaunchOptions {
      debug_prio debug_priority = err;
-     optional<string> device_file = nullopt;
-     optional<string> gcode_file = nullopt;
+     optional<string> device_file{};
+     optional<string> gcode_file{};
+
+     optional<individual_key_t> moveKey0{};
+     optional<individual_key_t> moveKey1{};
+     optional<individual_key_t> moveKey2{};
+     optional<individual_key_t> moveKey3{};
 };
 
 LaunchOptions parseArgs(int num_args, char * args[])
@@ -43,6 +48,12 @@ LaunchOptions parseArgs(int num_args, char * args[])
           if (currentArg == "-d") {
                // The next argument is the debug level.
                options.debug_priority = (enum debug_prio)strtol(args[i + 1], NULL, 10);
+               i += 2;
+               break;
+          }
+          if (currentArg == "--mk0") {
+               // The next argument is the move key
+               options.moveKey0 = stoi(args[i + 1], nullptr /* idx */, 16 /* base */);
                i += 2;
                break;
           }
@@ -67,9 +78,28 @@ LaunchOptions parseArgs(int num_args, char * args[])
 int main( int num_args, char * args[] )
 {
      const auto launchOptions = parseArgs(num_args, args);
-     if (!launchOptions.device_file || !launchOptions.gcode_file) {
+     if (!launchOptions.device_file || !launchOptions.gcode_file)
+     {
           usage(args[0]);
      }
+
+     // Verify that keys were set at compile time or that they were provided at runtime.
+     #ifdef NO_COMPILE_TIME_KEYS
+          if (!launchOptions.moveKey0)
+          {
+               cerr << "No move key was provided!" << endl;
+               cerr << endl;
+               usage(args[0]);
+          }
+
+          ckey_type move_key={*launchOptions.moveKey0, MOVE_KEY_1, MOVE_KEY_2, MOVE_KEY_3 };
+          ckey_type line_key={LINE_KEY_0, LINE_KEY_1, LINE_KEY_2, LINE_KEY_3 };
+          ckey_type curve_key={CURVE_KEY_0, CURVE_KEY_1, CURVE_KEY_2, CURVE_KEY_3 };
+     #else
+          ckey_type move_key={MOVE_KEY_0, MOVE_KEY_1, MOVE_KEY_2, MOVE_KEY_3 };
+          ckey_type line_key={LINE_KEY_0, LINE_KEY_1, LINE_KEY_2, LINE_KEY_3 };
+          ckey_type curve_key={CURVE_KEY_0, CURVE_KEY_1, CURVE_KEY_2, CURVE_KEY_3 };
+     #endif
 
      Device::C cutter(*launchOptions.device_file);
      gcode parser(*launchOptions.gcode_file, cutter);
@@ -78,13 +108,8 @@ int main( int num_args, char * args[] )
      cutter.stop();
      cutter.start();
 
-     ckey_type move_key={MOVE_KEY_0, MOVE_KEY_1, MOVE_KEY_2, MOVE_KEY_3 };
      cutter.set_move_key(move_key);
-
-     ckey_type line_key={LINE_KEY_0, LINE_KEY_1, LINE_KEY_2, LINE_KEY_3 };
      cutter.set_line_key(line_key);
-
-     ckey_type curve_key={CURVE_KEY_0, CURVE_KEY_1, CURVE_KEY_2, CURVE_KEY_3 };
      cutter.set_curve_key(curve_key);
 
      try

--- a/util/draw_gcode.cpp
+++ b/util/draw_gcode.cpp
@@ -83,10 +83,17 @@ int main( int num_args, char * args[] )
      const auto launchOptions = parseArgs(num_args, args);
      if (!launchOptions.device_file || !launchOptions.gcode_file)
      {
-          cerr << "Please provide a device file and GCode file" << endl;
+          #ifdef NO_COMPILE_TIME_KEYS
+               cerr << "Please provide a device file, GCode file, and key configuration file" << endl;
+          #else
+               cerr << "Please provide a device file and GCode file" << endl;
+          #endif
           cerr << endl;
           cerr << "Provided device: " << launchOptions.device_file.value_or("(missing)") << endl;
           cerr << "Provided GCode: " << launchOptions.gcode_file.value_or("(missing)") << endl;
+          #ifdef NO_COMPILE_TIME_KEYS
+               cerr << "Provided key config: " << (launchOptions.key_config ? "Provided" : "(missing)") << endl;
+          #endif;
           cerr << endl;
           usage(args[0]);
      }

--- a/util/draw_gcode.cpp
+++ b/util/draw_gcode.cpp
@@ -20,10 +20,20 @@ void usage(char *progname)
 {
      printf("Usage: %s <device file> <gcode file> -f <key config file> [-d debug_level]\n",
 	    progname);
-     // TODO besto
-     cout << "\t--mk - 4 move keys, separated by spaces, like this: `--mk 12ab56cd 87ab43cd 12ab56cd 87ab43cd`" << endl;
-     cout << "\t--lk - 4 line keys, separated by spaces, like this: `--lk 12ab56cd 87ab43cd 12ab56cd 87ab43cd`" << endl;
-     cout << "\t--ck - 4 curve keys, separated by spaces, like this: `--ck 12ab56cd 87ab43cd 12ab56cd 87ab43cd`" << endl;
+     cout << "\t-f - key configuration file, which contains cutting keys. For example (with fake keys):" << endl;
+     cout << endl;
+     cout << "\t\tMOVE_KEY_0  0x0123abcd" << endl;
+     cout << "\t\tMOVE_KEY_1  0x0123abcd" << endl;
+     cout << "\t\tMOVE_KEY_2  0x0123abcd" << endl;
+     cout << "\t\tMOVE_KEY_3  0x0123abcd" << endl;
+     cout << "\t\tLINE_KEY_0  0x0123abcd" << endl;
+     cout << "\t\tLINE_KEY_1  0x0123abcd" << endl;
+     cout << "\t\tLINE_KEY_2  0x0123abcd" << endl;
+     cout << "\t\tLINE_KEY_3  0x0123abcd" << endl;
+     cout << "\t\tCURVE_KEY_0  0x0123abcd" << endl;
+     cout << "\t\tCURVE_KEY_1  0x0123abcd" << endl;
+     cout << "\t\tCURVE_KEY_2  0x0123abcd" << endl;
+     cout << "\t\tCURVE_KEY_3  0x0123abcd" << endl;
      printf("%s\n", debug_msg.c_str());
      exit(1);
 }

--- a/util/draw_gcode.cpp
+++ b/util/draw_gcode.cpp
@@ -86,11 +86,11 @@ int main( int num_args, char * args[] )
           {
                return parseArgs(num_args, args);
           }
-          catch(const std::exception& e)
+          catch(const exception& e)
           {
-               std::cerr << "Failed to parse args:" << std::endl;
-               std::cerr << e.what() << std::endl;
-               std::cerr << std::endl;
+               cerr << "Failed to parse args:" << endl;
+               cerr << e.what() << endl;
+               cerr << endl;
                usage(args[0]);
                exit(1);
           }

--- a/util/draw_svg.cpp
+++ b/util/draw_svg.cpp
@@ -751,6 +751,10 @@ int main(int numArgs, char * args[] )
     c.stop();
     c.start();
 
+    #ifdef NO_COMPILE_TIME_KEYS
+        #warning This project requires compile-time keys.
+    #endif
+
     ckey_type move_key={MOVE_KEY_0, MOVE_KEY_1, MOVE_KEY_2, MOVE_KEY_3 };
     c.set_move_key(move_key);
 

--- a/util/interpreter.cpp
+++ b/util/interpreter.cpp
@@ -7,14 +7,56 @@ using namespace std;
 
 #include "keys.h"
 #include "device_c.hpp"
+#include "KeyConfigParser.hpp"
 
 int main( int numArgs, char * args[] )
 {
-    if( numArgs != 3 )
-    {
-        cout<<"Usage: "<<args[0]<<" /dev/serial/port filename"<<endl;
-        exit(1);
-    }
+    #ifdef NO_COMPILE_TIME_KEYS
+        if( numArgs != 4 )
+        {
+            cout<<"Usage: "<<args[0]<<" <device file> <input file> <key config file>"<<endl;
+            cout << endl;
+            cout << "\t<device file> - file of the cutter. Looks like '/dev/serial/port' or '/dev/cu.usbserial-10'" << endl;
+            cout << endl;
+            cout << "\t<input file> - file to interpret. Formatted:" << endl;
+            cout << endl;
+            cout << "\t\tMove to: m <x> <y>" << endl;
+            cout << "\t\tCut to: c <x> <y>" << endl;
+            cout << "\t\tCurve: b <x1> <y1> <x2> <y2> <x3> <y3> <x4> <y4>" << endl;
+            cout << "\t\tSleep: t <millis>" << endl;
+            cout << endl;
+            cout << "\t<key config file> - key configuration file, which contains cutting keys. For example (with fake keys):" << endl;
+            cout << endl;
+            cout << "\t\tMOVE_KEY_0  0x0123abcd" << endl;
+            cout << "\t\tMOVE_KEY_1  0x0123abcd" << endl;
+            cout << "\t\tMOVE_KEY_2  0x0123abcd" << endl;
+            cout << "\t\tMOVE_KEY_3  0x0123abcd" << endl;
+            cout << "\t\tLINE_KEY_0  0x0123abcd" << endl;
+            cout << "\t\tLINE_KEY_1  0x0123abcd" << endl;
+            cout << "\t\tLINE_KEY_2  0x0123abcd" << endl;
+            cout << "\t\tLINE_KEY_3  0x0123abcd" << endl;
+            cout << "\t\tCURVE_KEY_0  0x0123abcd" << endl;
+            cout << "\t\tCURVE_KEY_1  0x0123abcd" << endl;
+            cout << "\t\tCURVE_KEY_2  0x0123abcd" << endl;
+            cout << "\t\tCURVE_KEY_3  0x0123abcd" << endl;
+            exit(1);
+        }
+    #else
+        if( numArgs != 3 )
+        {
+            cout<<"Usage: "<<args[0]<<" <device file> <input file>"<<endl;
+            cout << endl;
+            cout << "\t<device file> - file of the cutter. Looks like '/dev/serial/port' or '/dev/cu.usbserial-10'" << endl;
+            cout << endl;
+            cout << "\t<input file> - file to interpret. Formatted:" << endl;
+            cout << endl;
+            cout << "\t\tMove to: m <x> <y>" << endl;
+            cout << "\t\tCut to: c <x> <y>" << endl;
+            cout << "\t\tCurve: b <x1> <y1> <x2> <y2> <x3> <y3> <x4> <y4>" << endl;
+            cout << "\t\tSleep: t <millis>" << endl;
+            exit(1);
+        }
+    #endif
 
     ifstream inputfile(args[2] );
     if(!inputfile )
@@ -24,11 +66,25 @@ int main( int numArgs, char * args[] )
     }
 
     Device::C c(args[1]);
-    ckey_type move_key={MOVE_KEY_0, MOVE_KEY_1, MOVE_KEY_2, MOVE_KEY_3 };
-    c.set_move_key(move_key);
 
-    ckey_type line_key={LINE_KEY_0, LINE_KEY_1, LINE_KEY_2, LINE_KEY_3 };
+    #ifdef NO_COMPILE_TIME_KEYS
+        KeyConfigParser keyConfig(args[3]);
+
+        auto moveKeys = keyConfig.moveKeys();
+        auto lineKeys = keyConfig.lineKeys();
+        auto curveKeys = keyConfig.curveKeys();
+        ckey_type move_key = { moveKeys.key0, moveKeys.key1, moveKeys.key2, moveKeys.key3 };
+        ckey_type line_key = { lineKeys.key0, lineKeys.key1, lineKeys.key2, lineKeys.key3 };
+        ckey_type curve_key = { curveKeys.key0, curveKeys.key1, curveKeys.key2, curveKeys.key3 };
+    #else
+        ckey_type move_key={MOVE_KEY_0, MOVE_KEY_1, MOVE_KEY_2, MOVE_KEY_3 };
+        ckey_type line_key={LINE_KEY_0, LINE_KEY_1, LINE_KEY_2, LINE_KEY_3 };
+        ckey_type curve_key={CURVE_KEY_0, CURVE_KEY_1, CURVE_KEY_2, CURVE_KEY_3 };
+    #endif
+
+    c.set_move_key(move_key);
     c.set_line_key(line_key);
+    c.set_curve_key(curve_key);
 
     c.stop();
     c.start();

--- a/util/interpreter_cv.cpp
+++ b/util/interpreter_cv.cpp
@@ -11,7 +11,16 @@ int main( int numArgs, char * args[] )
 {
     if( numArgs != 3 )
     {
-        cout<<"Usage: "<<args[0]<<" /dev/serial/port filename"<<endl;
+        cout<<"Usage: "<<args[0]<<" <device file> <input file>"<<endl;
+        cout << endl;
+        cout << "\t<device file> - file of the cutter. Looks like '/dev/serial/port' or '/dev/cu.usbserial-10'" << endl;
+        cout << endl;
+        cout << "\t<input file> - file to interpret. Formatted:" << endl;
+        cout << endl;
+        cout << "\t\tMove to: m <x> <y>" << endl;
+        cout << "\t\tCut to: c <x> <y>" << endl;
+        cout << "\t\tCurve: b <x1> <y1> <x2> <y2> <x3> <y3> <x4> <y4>" << endl;
+        cout << "\t\tSleep: t <millis>" << endl;
         exit(1);
     }
 

--- a/util/jsdrive.cpp
+++ b/util/jsdrive.cpp
@@ -67,6 +67,10 @@ void * thread( void * ptr )
     xy startpt={3,4};
     Device::C c( cutter_device );
 
+    #ifdef NO_COMPILE_TIME_KEYS
+        #warning This project requires compile-time keys.
+    #endif
+
     ckey_type move_key={MOVE_KEY_0, MOVE_KEY_1, MOVE_KEY_2, MOVE_KEY_3};
     c.set_move_key(move_key);
 

--- a/util/jsdrive_relative.cpp
+++ b/util/jsdrive_relative.cpp
@@ -67,6 +67,10 @@ void * thread( void * ptr )
     xy startpt={3,6};
     Device::C c( cutter_device );
 
+    #ifdef NO_COMPILE_TIME_KEYS
+        #warning This project requires compile-time keys.
+    #endif
+
     ckey_type move_key={MOVE_KEY_0, MOVE_KEY_1, MOVE_KEY_2, MOVE_KEY_3};
     c.set_move_key(move_key);
 

--- a/util/test_speed.cpp
+++ b/util/test_speed.cpp
@@ -36,6 +36,10 @@ int main(int argc, char *argv[])
     }
     Device::C cutter(argv[1]);
 
+    #ifdef NO_COMPILE_TIME_KEYS
+        #warning This project requires compile-time keys.
+    #endif
+
     ckey_type move_key={MOVE_KEY_0, MOVE_KEY_1, MOVE_KEY_2, MOVE_KEY_3};
     cutter.set_move_key(move_key);
 

--- a/util/test_speed.cpp
+++ b/util/test_speed.cpp
@@ -6,6 +6,7 @@
 using namespace std;
 
 #include "keys.h"
+#include "KeyConfigParser.hpp"
 
 void clean_up(int signal)
 {
@@ -29,21 +30,55 @@ int main(int argc, char *argv[])
 
     signal(SIGINT, clean_up);
 
-    if( argc != 2 )
-    {
-        cout << "usage: " << argv[0] << " device" << endl;
-        return 1;
-    }
+    #ifdef NO_COMPILE_TIME_KEYS
+        if( argc != 3 )
+        {
+            cout<<"Usage: "<<argv[0]<<" <device file>"<<endl;
+            cout << endl;
+            cout << "\t<device file> - file of the cutter. Looks like '/dev/serial/port' or '/dev/cu.usbserial-10'" << endl;
+            cout << endl;
+            cout << "\t<key config file> - key configuration file, which contains cutting keys. For example (with fake keys):" << endl;
+            cout << endl;
+            cout << "\t\tMOVE_KEY_0  0x0123abcd" << endl;
+            cout << "\t\tMOVE_KEY_1  0x0123abcd" << endl;
+            cout << "\t\tMOVE_KEY_2  0x0123abcd" << endl;
+            cout << "\t\tMOVE_KEY_3  0x0123abcd" << endl;
+            cout << "\t\tLINE_KEY_0  0x0123abcd" << endl;
+            cout << "\t\tLINE_KEY_1  0x0123abcd" << endl;
+            cout << "\t\tLINE_KEY_2  0x0123abcd" << endl;
+            cout << "\t\tLINE_KEY_3  0x0123abcd" << endl;
+            cout << "\t\tCURVE_KEY_0  0x0123abcd" << endl;
+            cout << "\t\tCURVE_KEY_1  0x0123abcd" << endl;
+            cout << "\t\tCURVE_KEY_2  0x0123abcd" << endl;
+            cout << "\t\tCURVE_KEY_3  0x0123abcd" << endl;
+            exit(1);
+        }
+    #else
+        if( argc != 2 )
+        {
+            cout<<"Usage: "<<argv[0]<<" <device file>"<<endl;
+            cout << endl;
+            cout << "\t<device file> - file of the cutter. Looks like '/dev/serial/port' or '/dev/cu.usbserial-10'" << endl;
+            cout << endl;
+            exit(1);
+        }
+    #endif
+
     Device::C cutter(argv[1]);
 
     #ifdef NO_COMPILE_TIME_KEYS
-        #warning This project requires compile-time keys.
+        KeyConfigParser keyConfig(argv[2]);
+
+        auto moveKeys = keyConfig.moveKeys();
+        auto lineKeys = keyConfig.lineKeys();
+        ckey_type move_key = { moveKeys.key0, moveKeys.key1, moveKeys.key2, moveKeys.key3 };
+        ckey_type line_key = { lineKeys.key0, lineKeys.key1, lineKeys.key2, lineKeys.key3 };
+    #else
+        ckey_type move_key={MOVE_KEY_0, MOVE_KEY_1, MOVE_KEY_2, MOVE_KEY_3 };
+        ckey_type line_key={LINE_KEY_0, LINE_KEY_1, LINE_KEY_2, LINE_KEY_3 };
     #endif
 
-    ckey_type move_key={MOVE_KEY_0, MOVE_KEY_1, MOVE_KEY_2, MOVE_KEY_3};
     cutter.set_move_key(move_key);
-
-    ckey_type line_key={LINE_KEY_0, LINE_KEY_1, LINE_KEY_2, LINE_KEY_3 };
     cutter.set_line_key(line_key);
 
     cutter.stop();


### PR DESCRIPTION
Hello! I want to set up a GitHub pipeline for this project, so that less-programmery folks can pick up and use libcutter.

To that end, I've implemented a quick-and-dirty way of **providing cutter keys at runtime**. Today, the build will warn if no keys are compiled in; with this change,`draw_gcode` will expect keys to be provided as arguments.

**Providing this as a slightly-early PR for feedback**. I think the arg parsing is very dirty; I'd rather parse a JSON file, but that's hard to do cross-platform. I'm open to reworking this code however makes sense.

## What changed?

* Add max-tested CMake version to avoid some warnings.
* Opt into C++17
* Update `keys.h` to no longer warn.
* Make `draw_gcode` argument parsing more robust
* ~~Add new `--mk`, `--lk`, and `--ck` flags to `draw_gcode`---they are required when no compile-time keys are present.~~
* Introduce a `KeyConfigParser` that can parse a specially-formatted configuration file.
* Consume that parser in `draw_gcode`, `draw_svg`, `interpreter`, and `test_speed`
* Document this behavior in README.

## How tested?

* [x] Drawing arbitrary GCode moves the machine & cuts when keys are provided at runtime
* [x] Drawing arbitrary SVG moves the machine & cuts when keys are provided at runtime
* [x] Running the interpreter moves the machine & cuts when keys are provided at runtime
* [x] Running `test_speed` moves the machine & cuts when keys are provided at runtime
* [ ] Drawing arbitrary GCode still moves the machine & cuts when keys are provided at compile-time
* [ ] Drawing arbitrary SVG still moves the machine & cuts when keys are provided at compile-time
* [ ] Running the interpreter still moves the machine & cuts when keys are provided at compile-time
* [ ] Running `test_speed` still moves the machine & cuts when keys are provided at compile-time

## TODO

* [x] Support these flags in `draw_svg`
* [ ] Hide these flags when compile-time keys are provided.