### PR TITLE
Added test case for implict lineto path on move command

### DIFF
--- a/util/svg_tests/path_explicit.svg
+++ b/util/svg_tests/path_explicit.svg
@@ -1,0 +1,3 @@
+<svg   version="1.1" viewBox="0 0 600 1200" height="12in" width="6in">
+<path d="M 100,300 L 100,500 500,500 500,300 Z" />
+</svg>

--- a/util/svg_tests/path_implicit.svg
+++ b/util/svg_tests/path_implicit.svg
@@ -1,0 +1,3 @@
+<svg   version="1.1" viewBox="0 0 600 1200" height="12in" width="6in">
+<path d="M 100,300 100,500 500,500 500,300 Z" />
+</svg>


### PR DESCRIPTION
Test case for implicit lineto action on move command with more than 2 coordinates.  The implicit file moves, but does not cut and doesn't close the move.  The explicit file cuts a rectangle properly.  Both render the same in svg viewers/editors.  